### PR TITLE
Map in load for dask

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,7 +1,8 @@
 igraph==0.1.11
+python-igraph==0.8.2
 leidenalg==0.8.0
 louvain==0.6.0
-umap-learn==0.3.9
+umap-learn==0.3.10
 pytest>=4.4
 fsspec
 zappy

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -183,7 +183,8 @@ def read_10x_h5(
         if gex_only:
             gx = adata.var['feature_types'].map(lambda x: x == 'Gene Expression')
             adata = adata[:, gx]
-        if adata.is_view:
+        if adata.is_view and not adata._dask:
+            # TODO: Ensure we can really skip the copy here.
             adata = adata.copy()
     else:
         adata = _read_legacy_10x_h5(filename, genome=genome, start=start, dask=dask)

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -181,10 +181,8 @@ def read_10x_h5(
                 )
             adata = adata[:, list(map(lambda x: x == str(genome), adata.var['genome']))]
         if gex_only:
-            adata = adata[
-                :,
-                list(map(lambda x: x == 'Gene Expression', adata.var['feature_types'])),
-            ]
+            gx = adata.var['feature_types'].map(lambda x: x == 'Gene Expression')
+            adata = adata[:, gx]
         if adata.is_view:
             adata = adata.copy()
     else:
@@ -451,9 +449,7 @@ def read_10x_mtx(
     if genefile_exists or not gex_only:
         return adata
     else:
-        gex_rows = list(
-            map(lambda x: x == 'Gene Expression', adata.var['feature_types'])
-        )
+        gex_rows = adata.var['feature_types'].map(lambda x: x == 'Gene Expression')
         return adata[:, gex_rows].copy()
 
 


### PR DESCRIPTION
### What this changes:

This is a tiny change to go with changes in AnnData to support dask.

Rather than `map(f, dataframe)` we call `dataframe.map(f)`.  This is identical on a `pandas.DataFrame`, and on dask calls an alternativee that makes a derived `dask.dataframe.DataFrame`.

### How this was tested:
- [x] pytest passes all tests

